### PR TITLE
Fix typo in index

### DIFF
--- a/apps/dynamic/views/index.slim
+++ b/apps/dynamic/views/index.slim
@@ -76,7 +76,7 @@ title: Cucumber
         a< href="http://sirenian.livejournal.com/"  Liz Keogh
         | ,
         a< href="http://blog.davidchelimsky.net/"  David Chelimsky
-        | and dozens of people on the RSpec and Cucumber mailing lists. And
+        | , and dozens of people on the RSpec and Cucumber mailing lists. And
         a< href="http://aslakhellesoy.com" Aslak.
       h1#upcoming-events Upcoming events
       .row.well


### PR DESCRIPTION
Fixing a small typo where a space--and depending on what you think of the serial/Oxford comma--a comma was missing. 
