### PR TITLE
Add a podcast feed redirect

### DIFF
--- a/apps/api/app.rb
+++ b/apps/api/app.rb
@@ -10,6 +10,8 @@ module Api
         # redirect all other api traffic to the legacy site
         # TODO: figure out a better place to host it
         r301 %r{(/api/.+)}, "http://cucumber.github.io$1"
+
+        r302 %r{/podcast/feed.xml}, "http://feeds.soundcloud.com/users/soundcloud:users:181591133/sounds.rss"
       end
     end
   end

--- a/apps/redirects/app.rb
+++ b/apps/redirects/app.rb
@@ -1,6 +1,6 @@
 require 'rack-rewrite'
 
-module Api
+module Redirects
   class App < Rack::Rewrite
     def initialize(app)
       super do

--- a/config.ru
+++ b/config.ru
@@ -15,7 +15,7 @@ end
 
 require 'newrelic_rpm'
 
-use Api::App
+use Redirects::App
 use CucumberEclipse::App
 use Cucumber::Website::Static::App
 run Cucumber::Website::App

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -106,5 +106,14 @@ describe "integration testing" do
       expect(last_response.status).to eq 301
       expect(last_response.location).to eq "http://cucumber.github.io/api/gherkin/"
     end
+
+    it "redirects the podcast to soundcloud" do
+      get "/podcast/feed.xml"
+      expect(last_response.status).to eq 302
+      expect(last_response.location).to eq "http://feeds.soundcloud.com/users/soundcloud:users:181591133/sounds.rss"
+    end
+  end
+
+  describe "rewrites" do
   end
 end


### PR DESCRIPTION
This will allow us to share a cucumber.io link for people to subscribe to the podcast in itunes etc.

We can also use it to add ourselves to various podcast directories.
