### PR TITLE
Add additional documentation for installation and running.

### DIFF
--- a/apps/dynamic/views/docs/reference/ruby.md
+++ b/apps/dynamic/views/docs/reference/ruby.md
@@ -24,6 +24,22 @@ group :test do
 end
 ```
 
+Then initialize a features directory:
+
+```
+cucumber --init
+```
+
 ## Running
 
-TODO
+To see the full list of options:
+
+```
+cucumber --help
+```
+
+Otherwise, to run all features:
+
+```
+cucumber
+```


### PR DESCRIPTION
The new Ruby documentation was lacking the most basic information. I have added the bare minimum.
