### PR TITLE
Update cucumber to match latest released version

### DIFF
--- a/apps/dynamic/_config.yml
+++ b/apps/dynamic/_config.yml
@@ -50,7 +50,7 @@ authors:
     gravatar: fbaa55683cc693c2e95f63431af00ed0
 
 versions:
-  cucumber_jvm: 1.2.4
+  cucumber_jvm: 1.2.5
 
 community:
   max_recent_contributors: 10


### PR DESCRIPTION
The website is currently referencing the 1.2.4 version of the cucumber jvm implementation. This version has a problem when used on Open JDK as described in [#912](/cucumber/cucumber-jvm/issues/912) which leads careless copy-pasters like me astray.